### PR TITLE
week1: 강병준 (5/5)

### DIFF
--- a/week1/bangdori/10713.py
+++ b/week1/bangdori/10713.py
@@ -1,0 +1,29 @@
+import sys
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+travel = list(map(int, input().split()))
+edges = [list(map(int, input().split())) for _ in range(n-1)]
+visit_count = [0 for _ in range(n+1)]
+
+# 1 -> 999일 떄, 1->2->3->...->999 다 찍으면 N번을 다 돌아버림. 그렇기에 총 O(N*M) 됨.
+# 그래서 그냥 i와 i+1 일 떄만 찍고, 누적합으로 계산
+for i in range(m-1):
+    if travel[i] < travel[i+1]:
+        visit_count[travel[i]] += 1
+        visit_count[travel[i+1]] -= 1
+    else:
+        visit_count[travel[i]] -= 1
+        visit_count[travel[i+1]] += 1
+
+for i in range(1, n):
+    visit_count[i] += visit_count[i-1]
+
+min_cost = 0
+# 최소 비용 구하기
+for i in range(1, n):
+    if visit_count[i] > 0:
+        ticket, passed, card = edges[i-1]
+        min_cost += min(card + visit_count[i] * passed, ticket * visit_count[i])
+
+print(min_cost)

--- a/week1/bangdori/1368.py
+++ b/week1/bangdori/1368.py
@@ -1,0 +1,38 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+costs = [int(input()) for _ in range(N)]
+board = [list(map(int, input().split())) for _ in range(N)]
+
+parent = [i for i in range(N+1)]
+
+def find(x):
+    if parent[x] == x: return x
+    parent[x] = find(parent[x])
+    return find(parent[x])
+
+def union(a, b):
+    pa, pb = find(a), find(b)
+    parent[min(pa, pb)] = max(pa, pb) 
+
+# 비용, a, b
+queue = []
+
+for i, cost in enumerate(costs):
+    queue.append((cost, 0, i+1))
+
+for r in range(N):
+    for c in range(N):
+        if r == c: continue
+        queue.append((board[r][c], r+1, c+1))
+
+queue.sort()
+
+answer = 0
+for cost, a, b in queue:
+    if find(a) != find(b):
+        union(a, b)
+        answer += cost
+
+print(answer)

--- a/week1/bangdori/20002.py
+++ b/week1/bangdori/20002.py
@@ -1,0 +1,19 @@
+import sys
+input = sys.stdin.readline
+
+SIZE = int(input())
+board = [list(map(int,input().split())) for _ in range(SIZE)]
+acc = [[0] * (SIZE+1) for _ in range(SIZE+1)]
+
+for i in range(1, SIZE+1):
+    for j in range(1, SIZE+1):
+        acc[i][j] = acc[i-1][j] + acc[i][j-1] - acc[i-1][j-1] + board[i-1][j-1]
+
+max_profit = acc[1][1]
+for size in range(SIZE):
+    for i in range(1, SIZE-size+1):
+        for j in range(1, SIZE-size+1):
+            current_profit = acc[i+size][j+size] - acc[i-1][j+size] - acc[i+size][j-1] + acc[i-1][j-1]
+            max_profit = max(max_profit, current_profit)
+
+print(max_profit)

--- a/week1/bangdori/20167.py
+++ b/week1/bangdori/20167.py
@@ -1,0 +1,27 @@
+import sys
+sys.setrecursionlimit(10 * 2)
+input = sys.stdin.readline
+
+food_cnt, need_satisfaction = map(int, input().split())
+food = [0] + list(map(int, input().split())) # Index 맞추기
+max_energy = 0
+
+# 먹는 경우와 먹지 않는 경우에 대한 백트래킹 함수
+def back_tracking(current_index, current_staisfaction, current_energy):
+    global max_energy
+    if current_index >= len(food):
+        max_energy = max(max_energy, current_energy)
+        return
+
+    next_satisfaction = current_staisfaction + food[current_index]
+    if next_satisfaction >= need_satisfaction:
+        next_energy = current_energy + (next_satisfaction - need_satisfaction)
+        back_tracking(current_index + 1, 0, next_energy) # 다음 만족도는 0에서 시작
+    else: back_tracking(current_index + 1, next_satisfaction, current_energy)
+    
+    # 아예 해당 구간 선택하지 않는 분기
+    # 문제 조건에서 애벌레는 '연속적으로' 먹을 때만 만족도가 누적된다.
+    back_tracking(current_index + 1, 0, current_energy)
+
+back_tracking(1, 0, 0)
+print(max_energy)

--- a/week1/bangdori/5549.py
+++ b/week1/bangdori/5549.py
@@ -1,0 +1,42 @@
+import sys
+input = sys.stdin.readline
+
+JUNGLE = 'J'; OCEAN ='O'; ICE = 'I'
+
+def calculateAccOfPos(row, col):
+    j1, o1, i1 = acc[row-1][col]
+    j2, o2, i2 = acc[row][col-1]
+    j3, o3, i3 = acc[row-1][col-1]
+    info = board[row-1][col-1]
+
+    j_cnt = j1+j2-j3
+    o_cnt = o1+o2-o3
+    c_cnt = i1+i2-i3
+    if info == JUNGLE: j_cnt += 1
+    elif info == OCEAN: o_cnt += 1
+    else: c_cnt += 1
+
+    return (j_cnt, o_cnt, c_cnt)
+
+def calculateSectionInfoOfPos(r1, c1, r2, c2):
+    j1, o1, i1 = acc[r2][c2]
+    j2, o2, i2 = acc[r1-1][c2]
+    j3, o3, i3 = acc[r2][c1-1]
+    j4, o4, i4 = acc[r1-1][c1-1]
+
+    return j1-j2-j3+j4, o1-o2-o3+o4, i1-i2-i3+i4
+
+row, col = map(int, input().split())
+K = int(input())
+board = [list(input().strip()) for _ in range(row)]
+
+# (J, O, I)
+acc = [[(0, 0, 0)] * (col+1) for _ in range(row+1)]
+
+for r in range(1, row+1):
+    for c in range(1, col+1):
+        acc[r][c] = calculateAccOfPos(r, c)
+
+for _ in range(K):
+    a, b, c, d = map(int, input().split())
+    print(*calculateSectionInfoOfPos(a, b, c, d))


### PR DESCRIPTION
## 1. 꿈틀꿈틀 호석 애벌레 - 기능성 (20167번)

- 아이디어: 재귀를 활용한 브루트포스

문제의 범위가 적기 때문에, 재귀를 활용해서 먹이를 먹는 경우와 먹지 않는 경우에 대해 분기 처리하여 문제를 해결함.

1. 먹이를 먹은 경우
  1-1. 탈피하는 경우
  1-2. 탈피하지 못하는 경우
2. 먹이를 먹지 않는 경우

3가지를 경우의 수로 두고 브루트포스로 해결
   
- 고민:

## 2. 사과나무 (20002번)

- 아이디어: 2차원 누적합 문제

누적합을 단일 방향으로 하는 것이 아닌, 정사각형 모양이 커지는 방향으로 누적합을 진행.
`ex) acc(1, 1) = acc(1, 0) + acc(0, 1) - acc(0, 0) + board(1, 1)`

이 때, acc(1, 1)을 구할때,  (0, 0)을 빼주는 이유가 acc(1, 0)에서 acc(0, 0)이 한 번, acc(0, 1)에서 acc(0, 0)이 한 번 나오기 때문에 acc(0, 0)이 두번 나옴. 그렇기 때문에 acc(0, 0)을 한 번 빼주는 것

이렇게 누적합을 구한 이후에, 누적합 2차원 배열에서 최대 수익을 구함. 최대 수익을 구할때에는 acc(i+size, j+size)를 구해야 함. `profit = acc(i+size, j+size) - acc(i-1, j+size) - acc(i+size, j-1) + acc(i-1, j-1)`

이때, acc(i-1, j+size)과 acc(i+size, j-1)를 빼주고 acc(i-1, j-1)를 더해주는 이유는 사각형을 기준으로 생각해보면 됨

![image](https://github.com/BangDori/coding-test-study/assets/44726494/afed50e1-98ed-43e6-b050-c8088509a634)

약간 위에 같은 느낌!

- 고민:

## 3. 행성 탐사 (5549번)

- 아이디어: 2차원 누적합 문제

2번과 똑같은 방법

- 고민:

## 4. 기차 여행 (10713번)

- 아이디어: 누적합

- 고민: 누적합을 이용해서 모든 기차역에 대한 방문 횟수를 계산했는데, 모든 기차역에 대한 방문 횟수를 누적합으로 구하는 아이디어를 구하기가 쉽지 않은데 어떻게 해야 바로 떠올릴 수 있을까요. 더 쉽고 빠르게 효율적으로 생각할 수 있는 방법이 뭐가 있을까요

## 5. 물대기 (10713번)

- 아이디어: 최소 스패닝 트리

배열로 주어지는 모든 정보들에 대해 queue에 넣고 비용으로 정렬한 이후에, union-find를 활용하여 연결되어 있지 않으면 연결하는 방식으로 해결