### PR TITLE
week1: 조유정(3/5)

### DIFF
--- a/week1/hiyoojeong/10713.java
+++ b/week1/hiyoojeong/10713.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+// 기차 여행
+public class No10713 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+
+		st = new StringTokenizer(br.readLine());
+		int n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+
+		Queue<Integer> plan = new LinkedList<>();
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < m; i++) {
+			plan.add(Integer.parseInt(st.nextToken()));
+		}
+
+		// costs[i] = i -> i+1로 가는 비용
+		int[][] costs = new int[n][3];
+		for (int i = 1; i < n; i++) {
+			st = new StringTokenizer(br.readLine());
+			costs[i][0] = Integer.parseInt(st.nextToken());
+			costs[i][1] = Integer.parseInt(st.nextToken());
+			costs[i][2] = Integer.parseInt(st.nextToken());
+		}
+
+		// uses[i] = i -> i+1로 가는 횟수
+		int[] uses = new int[n];
+		int pre = plan.poll();
+		while (!plan.isEmpty()) {
+			int current = plan.poll();
+
+			int start = Math.min(pre, current);
+			int end = Math.max(pre, current);
+			for (int i = start; i < start + (end - start); i++) {
+				uses[i]++;
+			}
+
+			pre = current;
+		}
+
+		long answer = 0;
+		for (int i = 1; i < n; i++) {
+			int cost = Math.min(costs[i][0] * uses[i], costs[i][1] * uses[i] + costs[i][2]);
+			answer += cost;
+		}
+		System.out.println(answer);
+	}
+
+}

--- a/week1/hiyoojeong/1368.java
+++ b/week1/hiyoojeong/1368.java
@@ -1,0 +1,96 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// 물대기
+public class No1368 {
+	static int n;
+	static int[] parents;
+
+	static class Node {
+		int from, to, cost;
+
+		public Node(int from, int to, int cost) {
+			this.from = from;
+			this.to = to;
+			this.cost = cost;
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+
+		n = Integer.parseInt(br.readLine());
+
+		// 논을 연결하는 비용
+		List<Node> costs = new ArrayList<>();
+
+		for (int i = 0; i < n; i++) { // 직접 논에 우물을 파는 방법
+			int cost = Integer.parseInt(br.readLine());
+			costs.add(new Node(i, i, cost));
+		}
+
+		for (int i = 0; i < n; i++) { // 이미 물을 대고 있는 다른 논으로부터 물을 끌어오는 방법
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < n; j++) {
+				int cost = Integer.parseInt(st.nextToken());
+				if (i < j) {
+					costs.add(new Node(i, j, cost));
+				}
+			}
+		}
+
+		// 비용 기준 오름차순으로 정렬
+		Collections.sort(costs, (o1, o2) -> o1.cost - o2.cost);
+
+		parents = new int[n + 1];
+		for (int i = 0; i < n + 1; i++) {
+			parents[i] = i;
+		}
+
+		int sum = 0, cnt = 0;
+		for (Node node : costs) {
+			if (union(node.from, node.to)) {
+				sum += node.cost;
+				cnt++;
+
+				if (cnt == n) {
+					break;
+				}
+			}
+		}
+
+		System.out.println(sum);
+
+	}
+
+	public static boolean union(int from, int to) {
+		int fromRoot = findSet(from);
+		int toRoot = findSet(to);
+
+		if (fromRoot == toRoot && from != to) {
+			return false;
+		}
+
+		if (fromRoot == toRoot && from == to) {
+			parents[toRoot] = n;
+			return true;
+		}
+
+		parents[toRoot] = fromRoot;
+		return true;
+	}
+
+	public static int findSet(int v) {
+		if (parents[v] == v) {
+			return v;
+		} else {
+			return parents[v] = findSet(parents[v]);
+		}
+	}
+}

--- a/week1/hiyoojeong/20002.java
+++ b/week1/hiyoojeong/20002.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 사과나무
+public class No20002 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+
+		int n = Integer.parseInt(br.readLine());
+		int[][] map = new int[n + 1][n + 1];
+		int[][] sum = new int[n + 1][n + 1];
+
+		for (int i = 1; i <= n; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 1; j <= n; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				sum[i][j] = sum[i - 1][j] + sum[i][j - 1] - sum[i - 1][j - 1] + map[i][j];
+			}
+		}
+		
+		for (int i = 0; i <= n; i++) {
+			for (int j = 0; j <= n; j++) {
+				System.out.print(sum[i][j] + " ");
+			}
+			System.out.println();
+		}
+
+		int max = Integer.MIN_VALUE;
+		for (int k = 0; k < n; k++) {
+			for (int i = 1; i <= n - k; i++) {
+				for (int j = 1; j <= n - k; j++) {
+					int value = sum[i + k][j + k] - sum[i + k][j - 1] - sum[i - 1][j + k] + sum[i - 1][j - 1];
+					max = Math.max(max, value);
+				}
+			}
+		}
+
+		System.out.println(max);
+	}
+
+}

--- a/week1/hiyoojeong/20167.java
+++ b/week1/hiyoojeong/20167.java
@@ -1,0 +1,51 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 꿈틀꿈틀 호석 애벌레 - 기능성
+public class No20167 {
+
+	static int n, k;
+	static int[] stick;
+	static int answer;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+
+		st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+
+		stick = new int[n];
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			stick[i] = Integer.parseInt(st.nextToken());
+		}
+
+		answer = 0;
+		dfs(0, 0, 0);
+
+		System.out.println(answer);
+	}
+
+	public static void dfs(int pos, int eat, int save) {
+		if (pos == n) {
+			answer = Math.max(save, answer);
+			return;
+		}
+
+		// 안 먹는 경우
+		dfs(pos + 1, 0, save);
+
+		// 먹는 경우
+		if (eat + stick[pos] >= k) {
+			dfs(pos + 1, 0, save + (eat + stick[pos] - k));
+		} else {
+			dfs(pos + 1, eat + stick[pos], save);
+		}
+
+	}
+
+}

--- a/week1/hiyoojeong/5549.java
+++ b/week1/hiyoojeong/5549.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 행성 탐사
+public class No5529 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+
+		st = new StringTokenizer(br.readLine());
+		int n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+		int testCase = Integer.parseInt(br.readLine());
+
+		int[][] jungle = new int[n + 1][m + 1];
+		int[][] ocean = new int[n + 1][m + 1];
+		int[][] ice = new int[n + 1][m + 1];
+
+		for (int i = 1; i <= n; i++) {
+			String input = br.readLine();
+			for (int j = 1; j <= m; j++) {
+				jungle[i][j] = jungle[i][j - 1] + jungle[i - 1][j] - jungle[i - 1][j - 1];
+				ocean[i][j] = ocean[i][j - 1] + ocean[i - 1][j] - ocean[i - 1][j - 1];
+				ice[i][j] = ice[i][j - 1] + ice[i - 1][j] - ice[i - 1][j - 1];
+				if (input.charAt(j - 1) == 'J') {
+					jungle[i][j]++;
+				} else if (input.charAt(j - 1) == 'O') {
+					ocean[i][j]++;
+				} else if (input.charAt(j - 1) == 'I') {
+					ice[i][j]++;
+				}
+			}
+		}
+
+		StringBuffer answer = new StringBuffer();
+		for (int t = 0; t < testCase; t++) {
+			st = new StringTokenizer(br.readLine());
+			int sx = Integer.parseInt(st.nextToken());
+			int sy = Integer.parseInt(st.nextToken());
+			int ex = Integer.parseInt(st.nextToken());
+			int ey = Integer.parseInt(st.nextToken());
+
+			int j = jungle[ex][ey] - jungle[sx - 1][ey] - jungle[ex][sy - 1] + jungle[sx - 1][sy - 1];
+			int o = ocean[ex][ey] - ocean[sx - 1][ey] - ocean[ex][sy - 1] + ocean[sx - 1][sy - 1];
+			int i = ice[ex][ey] - ice[sx - 1][ey] - ice[ex][sy - 1] + ice[sx - 1][sy - 1];
+			answer.append(j + " " + o + " " + i + "\n");
+		}
+		System.out.println(answer);
+
+	}
+
+}


### PR DESCRIPTION
## 1. 꿈틀꿈틀 호석 애벌레 - 기능성 (20167번)

### 아이디어: 
1 <= N <= 20, 1 <= K <= 100이라는 조건이 있기 때문에
**DFS**를 사용하여 해결할 수 있을 것이라고 생각하였다.

먹이 개수를 n, 최소 만족도를 k라고 두었고
먹의의 만족도는 1차원 배열 stick에 저장하였다.

먹이를 먹는 위치 pos는 0부터 n-1까지 순서대로 증가한다.
각 위치마다 크게 2가지의 선택을 할 수 있다.

**1. 먹이를 안 먹는 경우**
- 다음 먹이 위치로 이동
- 현재까지 먹은 양을 0으로 초기화
- 탈피 에너지 축적도는 그대로

**2. 먹이를 먹는 경우**
2-1) 먹이를 먹고 최소 만족도를 넘긴 경우
- 다음 먹이 위치로 이동
- 현재까지 먹은 양을 0으로 초기화
- 탈피 에너지 축적도를 "현재까지 먹은 양 - 최소만족도"만큼 더함

2-2) 먹이를 먹고 최소 만족도를 넘기지 않은 경우
- 다음 먹이 위치로 이동
- 현재까지 먹은 양을 업데이트
- 탈피 에너지 축적도는 그대로

### 고민:
처음에는 DP로 해결할 수 있을 것 같아 시도해보았지만, 실패하였다.
N, K 범위가 커지면 재귀적으로 해결할 수 없을 건데.. 라는 생각을 하였는데, 역시나 그런 문제가 있었다.
[백준 20181번: 꿈틀꿈틀 호석 에벌레 - 효율성](https://www.acmicpc.net/problem/20181)

DP로 어떻게 구현하면 좋을지 생각하고 있는 중이다.

## 2. 사과나무 (20002번)

### 아이디어:
**2차원 부분합**으로 풀이하였다.

<img width="1011" alt="image" src="https://github.com/BangDori/coding-test-study/assets/99192837/8d1ad1b1-e39d-45fd-9eb0-3416c7ca0c00">
예를 들면,
sum[2][2]에는 map 배열의 파란색 네모칸 값의 합이 저장되어 있다.

이후 정사각형의 크기 1부터 n까지 늘려가며
**해당 범위의 합**을 구한 뒤, 최대값을 업데이트 한다.

**해당 범위의 합 구하는 방법:
<img width="270" alt="image" src="https://github.com/BangDori/coding-test-study/assets/99192837/b8eaeab3-b169-4ced-94c0-274931662fbe">
부분합이 저장되어 있는 sum 배열을 사용하여 구할 수 있다.
i = 2, j = 2에서부터 정사각형 크기가 2인 범위를 구한다고 가정해보자.
정사각형의 가장 오른쪽 하단 부분에서 - 표시된 부분을 빼고, 중복으로 뺀 부분인 + 표시된 부분을 더해준다.
그렇게 하면, map 배열상에서 노란색 네모 부분의 합이 구해지는 것이다.

### 고민:
2차원 부분합을 생각할 수 있다면 쉽게 풀리는 문제였다.
인덱스만 잘 관리하면 된다.

## 3. 행성 탐사 (5549번)

### 아이디어:
**2차원 부분합**으로 풀이하였다.
정글, 바다, 얼음의 부분합을 저장하는 2차원 배열을 모두 생성하여 따로 관리하였다.

주어진 입력에 따라, 부분합 배열을 업데이트한다.

주어진 좌표 범위대로 부분합을 더하고 빼며 합을 구한다. ("2. 사과나무 (20002번)" 문제 참고)

### 고민:
2차원 부분합을 생각할 수 있다면 쉽게 풀리는 문제였다.
인덱스만 잘 관리하면 된다.

## 4. 기차 여행 (10713번) - 50% 성공

### 아이디어:
도시 수 n, 여행하는 기간 m을 저장한다.

plan이라는 큐를 사용하여, 여행하는 도시 순서를 저장하였다.

**int[][] costs = new int[n][3]
costs[i]는 i 도시에서 i+1 도시로 가는 기차 비용이다.
순서대로  티켓 구입 가격, IC 카드 사용 가격, IC 카드 구입 가격이다.

**int[] uses = new int[n]
uses[i]는 i 도시에서 i+1 도시 사이에 이동해야하는 실제 횟수이다.
여행하는 도시 순서에 따라 uses를 업데이트 한다.
<img width="256" alt="image" src="https://github.com/BangDori/coding-test-study/assets/99192837/16691c00-763b-4d5f-bc65-4f271b166dba">
여행하는 도시 순서가 1 - 3 - 2 - 4라면 배열에는 [1, 3, 1]이 저장된다.

이후, 1) 티켓을 구입하는 방법과 2) IC 카드를 구입하는 방법 중에 더 작은 비용이 드는 것을 선택한다.
1) 티켓을 구입하는 방법: cost[i][0] * uses[i]
2) IC 카드를 구입하는 방법: cost[i][1] * uses[i] + cost[i][2]

### 고민:
왜 50%만 맞을까요?

## 5. 물대기 (1368번) - 실패

### 아이디어:
**크루스칼 알고리즘**을 사용하여 최소신장 트리를 탐색하여 해결하고자 했다.

대신, 이 문제의 핵심은 
각 노드는 모두 연결되지 않아도 되며, 각 집합 중 하나의 노드는 스스로와 연결되어야 한다는 점이라고 생각했다.
<img width="425" alt="image" src="https://github.com/BangDori/coding-test-study/assets/99192837/d1aca1ed-c59b-4cde-98e2-41ebeccae1a7">
즉, 이런 식의 구조가 만들어진다는 것이다.
vertex 개수가 n이라면, edge 개수는 n이다.

Node 클래스는 연결하려는 두 개의 정점(from, to)과 연결하는 비용(cost)을 저장한다.
Node 타입의 리스트를 생성하여, 정점을 연결하는 비용이 적은 순서대로 저장하였다. 직접 논에 우물을 파는 방법은 자기 자신과 연결되는 경우이며, 이미 물을 대고 있는 다른 논으로부터 물을 끌어오는 방법은 다른 정점과 연결되는 경우이다.

리스트를 하나씩 살펴보며, 사이클이 생성되지 않는지 확인하고 연결한다.
**Union & Find** 방식을 사용하여 구현하였다.

이때 자기 자신과 연결되는 경우에는 부모 정점을 n(실제로 존재하지 않는 정점번호)으로 저장해두었다.

### 고민:
현재 StackOverFlow가 발생한 상태이다.
자기 자신과 연결되는 경우를 잘 처리하지 않아서 문제가 발생하는 것 같다...

## 자세히 봐주세요!

- 꿈틀꿈틀 호석 애벌레 - 기능성 (20167번) 문제 DP를 사용하여 효율적으로 풀려면 어떻게 접근하면 좋을까요?
- 기차 여행 (10713번) 문제 이렇게 했는데 왜 안되는걸까요? 반례가 있을까요?
- 물대기 (1368번) 문제 왜 StackOverFlow가 발생하는 걸까요? 어떤 부분이 문제일까요?
