### PR TITLE
week3: 강병준 (3/4)

### DIFF
--- a/week3/bangdori/1615_fail.py
+++ b/week3/bangdori/1615_fail.py
@@ -1,0 +1,36 @@
+# 1615
+# 간선의 개수는 최대 1,999,000
+
+# 모든 경우의 수를 확인하는 방법은 불가능 O(N^2) X
+# 이진 탐색으로 확인할 수 있지 않을까?
+
+# 메모리 초과 어떻게 해결함??????????? ㅡㅡ
+
+import sys
+input = sys.stdin.readline
+
+def binary_search(target):
+    left = 0
+    right = len(compare_line)-1
+    mid = (left + right) // 2
+
+    while left <= right:
+        mid = (left + right) // 2
+
+        if compare_line[mid][1] >= target: right = mid - 1
+        else: left = mid + 1
+    
+    return left
+
+N, M = map(int, input().split())
+lines = [list(map(int, input().split())) for _ in range(M)]
+lines.sort()
+
+answer = 0
+
+for i in range(len(lines)-1):
+    compare_line = lines[i+1:]
+    compare_line.sort(key=lambda v: v[1])
+    answer += binary_search(lines[i][1])
+
+print(answer)

--- a/week3/bangdori/16946.py
+++ b/week3/bangdori/16946.py
@@ -1,0 +1,63 @@
+# 16946
+# 벽이 아니라, 영역에 집중
+
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+# 영역 구하기
+def get_sections():
+    visited = [[False] * col for _ in range(row)]
+    sections = []
+    sizes = []
+    
+    for curr_r in range(row):
+        for curr_c in range(col):
+            if map[curr_r][curr_c] == WALL or visited[curr_r][curr_c]: continue
+
+            queue = deque([(curr_r, curr_c)])
+            visited[curr_r][curr_c] = True
+            
+            section = set()
+            size = 1
+
+            while queue:
+                r, c = queue.popleft()
+
+                for i in range(4):
+                    nr = r + dr[i]
+                    nc = c + dc[i]
+
+                    if 0 <= nr < row and 0 <= nc < col and not visited[nr][nc]:
+                        if map[nr][nc] == WALL:
+                            section.add((nr, nc))
+                        else:
+                            visited[nr][nc] = True
+                            size += 1
+                            queue.append((nr, nc))
+            
+            sections.append(section)
+            sizes.append(size)
+
+    return sections, sizes
+
+# 맵 변환하기
+def transform_map(sections, sizes):
+    for i, section in enumerate(sections):
+        for r, c in section:
+            map[r][c] += sizes[i]
+
+WALL = 1
+dr = [1, -1, 0, 0]
+dc = [0, 0, -1, 1]
+
+row, col = map(int, input().split())
+map = [list(map(int, list(input().strip()))) for _ in range(row)]
+
+sections, sizes = get_sections()
+transform_map(sections, sizes)
+
+for r in range(row):
+    for c in range(col):
+        print(map[r][c] % 10, end='')
+    print()

--- a/week3/bangdori/16946_fail.py
+++ b/week3/bangdori/16946_fail.py
@@ -1,0 +1,72 @@
+# 16946
+# 벽을 부쉈을 때, 이동 가능한 칸의 개수를 구하는 문제
+
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+# 주어진 맵에서 벽의 위치들을 반환하는 함수 O(r * c)
+def get_walls():
+    walls = []
+
+    for r in range(row):
+        for c in range(col):
+            if map[r][c] == WALL:
+                walls.append((r, c))
+    
+    return walls
+
+# 모든 벽을 순회하며, 변환된 벽의 정보를 반환해주는 함수
+def traverse_walls(walls):
+    transformed_walls = []
+
+    for wall in walls:
+        wr, wc = wall
+        count = calculate_move_count(wr, wc)
+
+        transformed_walls.append((wr, wc, count))
+    
+    return transformed_walls
+
+# 벽이 무너졌을 때 이동가능한 칸의 개수를 구하는 함수
+def calculate_move_count(wr, wc):
+    queue = deque([(wr, wc)])
+    visited = [[False] * col for _ in range(row)]
+
+    visited[wr][wc] = True
+    count = 1
+
+    while queue:
+        r, c = queue.popleft()
+
+        for dir in range(4):
+            nr = r + dr[dir]
+            nc = c + dc[dir]
+
+            if 0 <= nr < row and 0 <= nc < col and not visited[nr][nc] and map[nr][nc] != WALL:
+                visited[nr][nc] = True
+                queue.append((nr, nc))
+                count += 1
+
+    return count
+
+# 기존의 맵을 변환
+def transform_map(transformed_walls):
+    for r, c, count in transformed_walls:
+        map[r][c] = count % 10
+
+WALL = 1
+dr = [1, -1, 0, 0]
+dc = [0, 0, -1, 1]
+
+row, col = map(int, input().split())
+map = [list(map(int, list(input().strip()))) for _ in range(row)]
+
+walls = get_walls()
+transformed_walls = traverse_walls(walls)
+transform_map(transformed_walls)
+
+for r in range(row):
+    for c in range(col):
+        print(map[r][c], end='')
+    print()

--- a/week3/bangdori/4889.py
+++ b/week3/bangdori/4889.py
@@ -1,0 +1,43 @@
+# 4889
+
+import sys
+input = sys.stdin.readline
+
+OPEN = '{'; CLOSE = '}'
+
+current_case = 1
+while True:
+    datas = list(input().strip())
+    if datas[0] == "-": break
+
+    stack = []
+    change_count = 0
+
+    for data in datas:
+        # 스택이 비어있을 경우
+        if not stack:
+            if data == CLOSE:
+                change_count += 1
+                stack.append(OPEN)
+            else:
+                stack.append(data)
+
+        # 스택에 괄호가 존재하는 경우
+        else:
+            # 스택의 마지막이 열기이고, 데이터가 닫기라면
+            if stack[-1] == OPEN and data == CLOSE:
+                stack.pop()
+            else:
+                stack.append(data)
+    
+    # 스택의 마지막 데이터를 변환하면서 괄호 제거
+    while stack:
+        data1 = stack.pop()
+        data2 = stack.pop()
+
+        # 데이터가 동일하다면 변환 필요
+        if data1 == data2:
+            change_count += 1
+
+    print(f'{current_case}. {change_count}')
+    current_case += 1

--- a/week3/bangdori/5527.py
+++ b/week3/bangdori/5527.py
@@ -1,0 +1,40 @@
+# 5527
+# 교대 패턴 (0101010 or 101010...)
+
+# 전구의 영역을 분리?
+
+# ○ ○ ● ● ○ ● ○ ○ ○ ●
+# 1 1 0 0 1 0 1 1 1 0
+
+# (○) (○ ●) (● ○ ● ○) (○) (○ ●)
+# (1) (2) (4) (1) (2)
+# 1 + 2 + 4 = 7
+# 2 + 4 + 1 = 7
+# 4 + 1 + 2 = 7
+# ? 버근가
+
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+lights = list(map(int, input().split()))
+
+section = []
+
+length = 1
+for i in range(1, len(lights)):
+    if lights[i] != lights[i-1]: length += 1
+    else:
+        section.append(length)
+        length = 1
+section.append(length)
+
+answer = 0
+if len(section) == 1: answer = section[0]
+elif len(section) == 2:
+    answer = section[0] + section[1]
+else:
+    for i in range(2, len(section)):
+        answer = max(answer, section[i]+section[i-1]+section[i-2])
+
+print(answer)


### PR DESCRIPTION
## 1. 전구 장식

- 아이디어

아이디어라고 하기애도 애매한 부분이, 그냥 혼자 노트에 끄적끄적 거리다가 다음과 같은 정보를 알게 되었다.

```
○ ○ ● ● ○ ● ○ ○ ○ ●
1 1 0 0 1 0 1 1 1 0
```

위와 같은 전구가 놓여져 있을 때, 위 전구에서 교차 패턴이 초기에 어떻게 형성되어 있는지를 먼저 확인하였다.

```
(○) (○ ●) (● ○ ● ○) (○) (○ ●)
(1) (2) (4) (1) (2)
```

그랬더니 위와 같이 교차 패턴이 만들어지는 것을 알 수 있었고, 3개의 영역을 합치는 것까지 1번의 변화만으로 교차 패턴을 만들 수 있다는 사실을 알게 되었다.

- 고민: 이 방법은 너무.. 운빨인 거 같다; 조금 더 정형화된? 방법이 없을까?

## 2. 안정적인 문자열

- 아이디어

스택을 활용한 방법으로 괄호를 제거해나가면서 문제를 해결할 수 있다고 생각하였다.

하지만, 중요한 점이 초기에 스택에 데이터(괄호)가 없을 경우에는 `}` 닫는 괄호를 넣으면 안된다는 사실이다. 왜냐하면 결국에 괄호는 `{}` 이렇게 안정화된 괄호가 되어야만 사라지게 되기 때문이다.

그래서 우선 스택에 어떠한 데이터도 없을 경우에는 초기에 항상 괄호를 `{`로 넣도록 하였다.

```
if 스택이 비어 있다면:
    if 현재 괄호가 닫는 괄호라면:
        괄호를 여는 괄호로 변경한다.
        여는 괄호를 스택에 삽입한다.
    else:
        여는 괄호를 스택에 삽입한다.
```

그리고 마지막 까지 순회를 진행하면, 여는 괄호와 닫는 괄호의 조합을 안정화된 괄호는 모두 제거되고 스택에 찌꺼기가 남는다. 여기서 찌꺼기는 여는 괄호를 의미한다. 닫는 괄호는 모두 없어졌기 때문에, 여는 괄호만 남아있을 것이다.

그렇기에 다음과 같이 스택에 남아있는 부분을 모두 제거하는 과정을 거쳤다.

```
while 스택에 괄호가 없을때까지:
    스택에서 데이터를 pop한다.
    스택에서 데이터를 pop한다.
    
    pop한 두 개의 데이터는 여는 괄호이기 때문에, 여는 괄호 하나를 닫는 괄호로 변환한다.
```

스택에는 항상 짝수개의 데이터가 남아있기 때문에, 하나만 남아있을 경우에 대해서는 고려하지 않았다.

## 3. 벽 부수고 이동하기4

- 아이디어

### 아이디어 1

처음에는 모든 벽에 대한 위치를 구하고나서, 모든 벽을 순회하면서 벽에서 갈 수 있는 칸의 개수를 구하는 방법으로 문제를 접근했다.

하지만 이 방법의 경우 모든 벽에서 이동 가능한 칸의 개수를 모두 세어야 해야했기때문에, 시간복잡도를 정확히 계산하기도 힘들었고 시간 초과가 발생했다.

![image](https://github.com/BangDori/coding-test-study/assets/44726494/8b57f6a7-2cdd-4035-8c85-00bd40bb0be8)

### 아이디어 2

모든 벽에서 이동 가능한 칸의 개수를 세는 것은 무리라고 생각하여, 다른 아이디어를 생각해보았다.

BFS를 진행하는 횟수를 줄이는 방법에 대해 고민을 해보았는데, 벽이 아니라 이동 가능한 칸(`0`)이 모여있는 영역에 대해 집중하기로 했다. 우선 영역에 대해 영역의 크기 (`size`)를 구하고, 영역을 둘러싸고 있는 벽을 구했다.

이후 영역을 둘러싸고 있는 벽에 영역의 크기를 추가해주었다.

```
def transform_map(sections, sizes):
    for i, section in enumerate(sections):
        for r, c in section:
            map[r][c] += sizes[i]
```

이렇게 함으로써 영역별로 BFS의 횟수를 1번으로 줄일 수 있어 시간복잡도가 크게 향상되어 문제를 해결할 수 있었다.

## 4. 교차개수세기

- 아이디어

간선의 개수가 최대 1,999,000으로 잡히기 때문에, 단순히 이중 반복문으로는 문제를 해결할 수 없다고 생각하여서 logN으로 해결할 수 있는 이진 탐색에 대한 방법을 생각해보았다.

우선 입력받은 간선을 왼쪽 그룹을 기준으로 정렬하였다. 그리고, 왼쪽 그룹의 i번째 간선이 어디로 이동하는지를 확인한 다음 i번째 간선이 이동한 점 j번보다 이하인 부분을 구하기 위해 이진 탐색을 적용하였다.

하지만 이 방법으로하니 바로 메모리 초과가 발생해버렸다.

- 고민

솔직히 말하면 어떻게 해결해야 할 지 모르겠다. 답지를 봐야겠다.
